### PR TITLE
Enhance GitHub Actions workflow for Terraform CI/CD and release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -304,14 +304,13 @@ jobs:
     - terraform-destroy
     steps:
       - name: Create Release
-        run: echo "Creating release..."
         uses: subhamay-bhattacharyya-gha/create-release-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          tag-name: ${{ github.ref_name }}
-          release-name: Release ${{ github.ref_name }}
-          release-body: |
-            This is an automated release created by the CI pipeline.
-            It includes the latest changes from the main branch.
-          draft: false
-          prerelease: false
+          # tag-name: ${{ github.ref_name }}
+          # release-name: Release ${{ github.ref_name }}
+          # release-body: |
+          #   This is an automated release created by the CI pipeline.
+          #   It includes the latest changes from the main branch.
+          # draft: false
+          # prerelease: false

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -72,15 +72,15 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # - name: Terraform Validation and Formatting Checks
-      #   id: validate
-      #   uses: subhamay-bhattacharyya-gha/tf-validate-action@main
-      #   with:
-      #     terraform-dir: ${{ inputs.terraform-dir }}              
-      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-      #     s3-region: ${{ vars.AWS_REGION }}
-      #     ci-pipeline: "true"
-      #     soft-fail: "true"                                  
+      - name: Terraform Validation and Formatting Checks
+        id: validate
+        uses: subhamay-bhattacharyya-gha/tf-validate-action@main
+        with:
+          terraform-dir: ${{ inputs.terraform-dir }}              
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+          s3-region: ${{ vars.AWS_REGION }}
+          ci-pipeline: "true"
+          soft-fail: "true"                                  
 
   terraform-lint:
     name: 📋 Terraform Lint
@@ -88,15 +88,12 @@ jobs:
     needs: [execution-path]
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
     steps:
-      # - name: Run TFLint
-      #   uses: subhamay-bhattacharyya-gha/tf-lint-action@main
-      #   with:
-      #     tflint-ver: "v0.52.0"
-      #     use-cache: "true"
-      #     tflint-format: "compact"
       - name: Run TFLint
-        run: |
-          echo "Running TFLint..."
+        uses: subhamay-bhattacharyya-gha/tf-lint-action@main
+        with:
+          tflint-ver: ${{ vars.TF_LINT_VER }}
+          use-cache: "true"
+          tflint-format: "compact"
           
   checkov-scan:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
@@ -112,23 +109,23 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # - name: Checkov Scan
-      #   uses: subhamay-bhattacharyya-gha/checkov-scan-action@main
-      #   id: checkov-scan
-      #   with:
-      #     iac-dir: ${{ inputs.terraform-dir }}
-      #     iac-framework: terraform
-      #     soft-fail: true
+      - name: Checkov Scan
+        uses: subhamay-bhattacharyya-gha/checkov-scan-action@main
+        id: checkov-scan
+        with:
+          iac-dir: ${{ inputs.terraform-dir }}
+          iac-framework: terraform
+          soft-fail: true
 
-      # - name: Confirm SARIF file type
-      #   shell: bash
-      #   run: |
-      #     ls -la "${{ github.workspace }}"
-      #     file "${{ github.workspace }}/results.sarif"
+      - name: Confirm SARIF file type
+        shell: bash
+        run: |
+          ls -la "${{ github.workspace }}"
+          file "${{ github.workspace }}/results.sarif"
 
-      # - name: "📋 Summarize and Print Checkov Scan Report with Snippets"
-      #   id: summarize-report
-      #   uses: subhamay-bhattacharyya-gha/checkov-report-action@main
+      - name: "📋 Summarize and Print Checkov Scan Report with Snippets"
+        id: summarize-report
+        uses: subhamay-bhattacharyya-gha/checkov-report-action@main
 
   build-lambda:
     name: 🛠️ ⛔ Lambda Package
@@ -187,9 +184,9 @@ jobs:
     steps:
       - name: Call Yor Reusable Action
         run: echo "Applying Git metadata tags using YOR..."
-        # uses: subhamay-bhattacharyya-gha/tf-yor-action@main
-        # with:
-        #   terraform-dir: ${{ inputs.terraform-dir }}
+        uses: subhamay-bhattacharyya-gha/tf-yor-action@main
+        with:
+          terraform-dir: ${{ inputs.terraform-dir }}
          
   terraform-plan:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
@@ -204,15 +201,15 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # - name: Terraform Plan
-      #   id: plan
-      #   uses: subhamay-bhattacharyya-gha/tf-plan-action@main
-      #   with:
-      #     terraform-dir: ${{ inputs.terraform-dir }} 
-      #     tf-vars-file: ${{ inputs.tf-vars-file }}
-      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-      #     s3-region: ${{ vars.AWS_REGION }}
-      #     ci-pipeline: ${{ inputs.ci-pipeline }}
+      - name: Terraform Plan
+        id: plan
+        uses: subhamay-bhattacharyya-gha/tf-plan-action@main
+        with:
+          terraform-dir: ${{ inputs.terraform-dir }} 
+          tf-vars-file: ${{ inputs.tf-vars-file }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+          s3-region: ${{ vars.AWS_REGION }}
+          ci-pipeline: ${{ inputs.ci-pipeline }}
 
   infra-cost:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
@@ -227,17 +224,17 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # - name: Infra Cost
-      #   id: infra-cost
-      #   uses: subhamay-bhattacharyya-gha/infracost-action@main
-      #   with:
-      #     terraform-dir: ${{ inputs.terraform-dir }} 
-      #     ci-pipeline: ${{ inputs.ci-pipeline }}
-      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-      #     s3-region: ${{ vars.AWS_REGION }}
-      #     infracost-api-key: ${{ secrets.infracost-api-key }}
-      #     gist-id: ${{ secrets.infracost-gist-id }}
-      #     environment: ${{ inputs.environment }}
+      - name: Infra Cost
+        id: infra-cost
+        uses: subhamay-bhattacharyya-gha/infracost-action@main
+        with:
+          terraform-dir: ${{ inputs.terraform-dir }} 
+          ci-pipeline: ${{ inputs.ci-pipeline }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+          s3-region: ${{ vars.AWS_REGION }}
+          infracost-api-key: ${{ secrets.infracost-api-key }}
+          gist-id: ${{ secrets.infracost-gist-id }}
+          environment: ${{ inputs.environment }}
 
   terraform-apply:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
@@ -252,14 +249,14 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # - name: Terraform Apply
-      #   uses: subhamay-bhattacharyya-gha/tf-apply-action@main
-      #   id: apply
-      #   with:
-      #     terraform-dir: ${{ inputs.terraform-dir }}
-      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-      #     s3-region: ${{ vars.AWS_REGION }}
-      #     ci-pipeline: ${{ inputs.ci-pipeline }}
+      - name: Terraform Apply
+        uses: subhamay-bhattacharyya-gha/tf-apply-action@main
+        id: apply
+        with:
+          terraform-dir: ${{ inputs.terraform-dir }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+          s3-region: ${{ vars.AWS_REGION }}
+          ci-pipeline: ${{ inputs.ci-pipeline }}
 
   terraform-destroy:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
@@ -275,14 +272,14 @@ jobs:
           role-to-assume: ${{ secrets.aws-role-arn }}
           aws-region: ${{ vars.AWS_REGION }}
 
-      # - name: Terraform Destroy
-      #   uses: subhamay-bhattacharyya-gha/tf-destroy-action@main
-      #   id: destroy
-      #   with:
-      #     terraform-dir: ${{ inputs.terraform-dir }}
-      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
-      #     s3-region: ${{ vars.AWS_REGION }}
-      #     ci-pipeline: ${{ inputs.ci-pipeline }}
+      - name: Terraform Destroy
+        uses: subhamay-bhattacharyya-gha/tf-destroy-action@main
+        id: destroy
+        with:
+          terraform-dir: ${{ inputs.terraform-dir }}
+          s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+          s3-region: ${{ vars.AWS_REGION }}
+          ci-pipeline: ${{ inputs.ci-pipeline }}
 
   create-release:
     name: 🚀 Create Release
@@ -308,13 +305,13 @@ jobs:
     steps:
       - name: Create Release
         run: echo "Creating release..."
-        # uses: subhamay-bhattacharyya-gha/create-release-action@main
-        # with:
-        #   github-token: ${{ secrets.GITHUB_TOKEN }}
-        #   tag-name: ${{ github.ref_name }}
-        #   release-name: Release ${{ github.ref_name }}
-        #   release-body: |
-        #     This is an automated release created by the CI pipeline.
-        #     It includes the latest changes from the main branch.
-        #   draft: false
-        #   prerelease: false
+        uses: subhamay-bhattacharyya-gha/create-release-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-name: ${{ github.ref_name }}
+          release-name: Release ${{ github.ref_name }}
+          release-body: |
+            This is an automated release created by the CI pipeline.
+            It includes the latest changes from the main branch.
+          draft: false
+          prerelease: false

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -177,6 +177,7 @@ jobs:
         uses: subhamay-bhattacharyya-gha/tf-yor-action@main
         with:
           terraform-dir: ${{ inputs.terraform-dir }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   terraform-plan:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -304,13 +304,6 @@ jobs:
     - terraform-destroy
     steps:
       - name: Create Release
-        uses: subhamay-bhattacharyya-gha/create-release-action@main
+        uses: subhamay-bhattacharyya-gha/create-release-action@feature/GHA-0002-initial-release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # tag-name: ${{ github.ref_name }}
-          # release-name: Release ${{ github.ref_name }}
-          # release-body: |
-          #   This is an automated release created by the CI pipeline.
-          #   It includes the latest changes from the main branch.
-          # draft: false
-          # prerelease: false

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,9 +1,8 @@
-name: Terraform Release Pipeine (Reusable)
+name: Terraform Release Pipeline (Reusable)
 description: |
   This is a reusable GitHub Actions workflow for CI/CD using Terraform.
   It includes steps for linting, validating, scanning, and building AWS resources.
   The workflow is designed to be triggered by other workflows or manually.
-  It also includes steps for checking environments, detecting changes, and preparing builds.
 
 on:
   workflow_call:
@@ -41,8 +40,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  # actions: read
-
 
 jobs:
 
@@ -51,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       execution-path: ${{ steps.set-path.outputs.execution-path }}
-
     steps:
       - name: Set Execution Path
         id: set-path
@@ -65,7 +61,6 @@ jobs:
     environment: ${{ inputs.environment }}
     needs: [execution-path]
     steps:
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -76,17 +71,17 @@ jobs:
         id: validate
         uses: subhamay-bhattacharyya-gha/tf-validate-action@main
         with:
-          terraform-dir: ${{ inputs.terraform-dir }}              
+          terraform-dir: ${{ inputs.terraform-dir }}
           s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
-          ci-pipeline: "true"
-          soft-fail: "true"                                  
+          ci-pipeline: ${{ inputs.ci-pipeline }}
+          soft-fail: "true"
 
   terraform-lint:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
     name: 📋 Terraform Lint
     runs-on: ubuntu-latest
     needs: [execution-path]
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
     steps:
       - name: Run TFLint
         uses: subhamay-bhattacharyya-gha/tf-lint-action@main
@@ -94,7 +89,7 @@ jobs:
           tflint-ver: ${{ vars.TF_LINT_VER }}
           use-cache: "true"
           tflint-format: "compact"
-          
+
   checkov-scan:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
     name: 🧳 Checkov Scan
@@ -102,7 +97,6 @@ jobs:
     environment: ${{ inputs.environment }}
     needs: [execution-path]
     steps:
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -110,8 +104,8 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Checkov Scan
-        uses: subhamay-bhattacharyya-gha/checkov-scan-action@main
         id: checkov-scan
+        uses: subhamay-bhattacharyya-gha/checkov-scan-action@main
         with:
           iac-dir: ${{ inputs.terraform-dir }}
           iac-framework: terraform
@@ -123,13 +117,13 @@ jobs:
           ls -la "${{ github.workspace }}"
           file "${{ github.workspace }}/results.sarif"
 
-      - name: "📋 Summarize and Print Checkov Scan Report with Snippets"
+      - name: 📋 Summarize and Print Checkov Scan Report
         id: summarize-report
         uses: subhamay-bhattacharyya-gha/checkov-report-action@main
 
   build-lambda:
-    name: 🛠️ ⛔ Lambda Package
-    if: ${{ toJSON(needs.execution-path.outputs.execution-path).lambda == true }}
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).lambda == true }}
+    name: 🛠️ Lambda Package
     runs-on: ubuntu-latest
     needs: [execution-path]
     steps:
@@ -137,24 +131,22 @@ jobs:
         run: echo "Uploading Lambda package..."
 
   build-lambda-layer:
-    name: 🛠️ ⛔ Lambda Layer
-    if: ${{ toJSON(needs.execution-path.outputs.execution-path)['lambda-layer'] == true }}
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).lambda-layer == true }}
+    name: 🛠️ Lambda Layer
     runs-on: ubuntu-latest
     needs: [execution-path]
     steps:
-    
       - name: Build Lambda Layer Package
         run: echo "No changes in Lambda layer package, skipping build..."
 
       - name: Build and Upload Lambda Layer Package
-        run: echo "Build and Upload Lambda layer...."
+        run: echo "Build and Upload Lambda layer..."
 
   build-glue:
-    name: 🛠️ ⛔ Glue Script
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).glue == true }}
+    name: 🛠️ Glue Script
     runs-on: ubuntu-latest
     needs: [execution-path]
-    
     steps:
       - name: Package Glue Script
         run: echo "No changes found in Glue script, skipping build..."
@@ -163,12 +155,11 @@ jobs:
         run: echo "Uploading Glue script..."
 
   build-state-machine:
-    name: 🛠️ ⛔ State Machine
-    if: ${{ fromJSON(needs.execution-path.outputs.execution-path)['state-machine'] == true }}
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).state-machine == true }}
+    name: 🛠️ State Machine
     runs-on: ubuntu-latest
     needs: [execution-path]
     steps:
-
       - name: Package State Machine
         run: echo "No changes in State Machine, skipping build."
 
@@ -180,19 +171,19 @@ jobs:
     name: 📋 Apply Git Metadata Tags using YOR
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: [ terraform-lint, terraform-validate, checkov-scan ]
+    needs: [terraform-lint, terraform-validate, checkov-scan]
     steps:
       - name: Call Yor Reusable Action
         uses: subhamay-bhattacharyya-gha/tf-yor-action@main
         with:
           terraform-dir: ${{ inputs.terraform-dir }}
-         
+
   terraform-plan:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
     name: 📋 Terraform Plan
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    needs: [ yor-resource-tagging ]
+    needs: [yor-resource-tagging]
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -204,7 +195,7 @@ jobs:
         id: plan
         uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         with:
-          terraform-dir: ${{ inputs.terraform-dir }} 
+          terraform-dir: ${{ inputs.terraform-dir }}
           tf-vars-file: ${{ inputs.tf-vars-file }}
           s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
@@ -227,7 +218,7 @@ jobs:
         id: infra-cost
         uses: subhamay-bhattacharyya-gha/infracost-action@main
         with:
-          terraform-dir: ${{ inputs.terraform-dir }} 
+          terraform-dir: ${{ inputs.terraform-dir }}
           ci-pipeline: ${{ inputs.ci-pipeline }}
           s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
           s3-region: ${{ vars.AWS_REGION }}
@@ -249,8 +240,8 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Terraform Apply
-        uses: subhamay-bhattacharyya-gha/tf-apply-action@main
         id: apply
+        uses: subhamay-bhattacharyya-gha/tf-apply-action@main
         with:
           terraform-dir: ${{ inputs.terraform-dir }}
           s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
@@ -264,7 +255,6 @@ jobs:
     environment: ${{ inputs.environment }}
     needs: [terraform-apply]
     steps:
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -272,8 +262,8 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Terraform Destroy
-        uses: subhamay-bhattacharyya-gha/tf-destroy-action@main
         id: destroy
+        uses: subhamay-bhattacharyya-gha/tf-destroy-action@main
         with:
           terraform-dir: ${{ inputs.terraform-dir }}
           s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
@@ -283,24 +273,19 @@ jobs:
   create-release:
     name: 🚀 Create Release
     runs-on: ubuntu-latest
-    if: |
-        (needs.build-lambda.result == 'success' ||
-          needs.build-lambda-layer.result == 'success' ||
-          needs.build-glue.result == 'success' ||
-          needs.build-state-machine.result == 'success' ||
-          needs.terraform-destroy.result == 'success')
-    needs: 
-    - build-lambda
-    - build-lambda-layer
-    - build-glue
-    - build-state-machine
-    - terraform-validate
-    - terraform-lint
-    - checkov-scan
-    - infra-cost
-    - terraform-plan
-    - terraform-apply
-    - terraform-destroy
+    if: ${{ needs.build-lambda.result == 'success' || needs.build-lambda-layer.result == 'success' || needs.build-glue.result == 'success' || needs.build-state-machine.result == 'success' || needs.terraform-destroy.result == 'success' }}
+    needs:
+      - build-lambda
+      - build-lambda-layer
+      - build-glue
+      - build-state-machine
+      - terraform-validate
+      - terraform-lint
+      - checkov-scan
+      - infra-cost
+      - terraform-plan
+      - terraform-apply
+      - terraform-destroy
     steps:
       - name: Create Release
         uses: subhamay-bhattacharyya-gha/create-release-action@feature/GHA-0002-initial-release

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,319 @@
+name: Terraform Release Pipeine (Reusable)
+description: |
+  This is a reusable GitHub Actions workflow for CI/CD using Terraform.
+  It includes steps for linting, validating, scanning, and building AWS resources.
+  The workflow is designed to be triggered by other workflows or manually.
+  It also includes steps for checking environments, detecting changes, and preparing builds.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Environment to deploy to (e.g., ci, devl, test, prod)."
+        required: true
+        type: string
+      terraform-dir:
+        description: "Directory containing Terraform configuration files."
+        required: true
+        type: string
+        default: "tf"
+      tf-vars-file:
+        description: "Terraform variables file to use."
+        required: false
+        type: string
+        default: "terraform.tfvars"
+      ci-pipeline:
+        description: "Indicates if this is a CI pipeline run."
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      aws-role-arn:
+        description: "AWS role ARN for assuming a role."
+        required: true
+      infracost-api-key:
+        description: "API key for Infracost."
+        required: true
+      infracost-gist-id:
+        description: "Gist ID for Infracost output."
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+  # actions: read
+
+
+jobs:
+
+  execution-path:
+    name: 🔎 Get Exec. Path
+    runs-on: ubuntu-latest
+    outputs:
+      execution-path: ${{ steps.set-path.outputs.execution-path }}
+
+    steps:
+      - name: Set Execution Path
+        id: set-path
+        run: |
+          echo "execution-path={\"IaC\": true, \"lambda\": true, \"lambda-layer\": false, \"glue\": false, \"state-machine\": false}" >> $GITHUB_OUTPUT
+
+  terraform-validate:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    name: ✔️ Terraform Validate
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [execution-path]
+    steps:
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # - name: Terraform Validation and Formatting Checks
+      #   id: validate
+      #   uses: subhamay-bhattacharyya-gha/tf-validate-action@main
+      #   with:
+      #     terraform-dir: ${{ inputs.terraform-dir }}              
+      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+      #     s3-region: ${{ vars.AWS_REGION }}
+      #     ci-pipeline: "true"
+      #     soft-fail: "true"                                  
+
+  terraform-lint:
+    name: 📋 Terraform Lint
+    runs-on: ubuntu-latest
+    needs: [execution-path]
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    steps:
+      # - name: Run TFLint
+      #   uses: subhamay-bhattacharyya-gha/tf-lint-action@main
+      #   with:
+      #     tflint-ver: "v0.52.0"
+      #     use-cache: "true"
+      #     tflint-format: "compact"
+      - name: Run TFLint
+        run: |
+          echo "Running TFLint..."
+          
+  checkov-scan:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    name: 🧳 Checkov Scan
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [execution-path]
+    steps:
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # - name: Checkov Scan
+      #   uses: subhamay-bhattacharyya-gha/checkov-scan-action@main
+      #   id: checkov-scan
+      #   with:
+      #     iac-dir: ${{ inputs.terraform-dir }}
+      #     iac-framework: terraform
+      #     soft-fail: true
+
+      # - name: Confirm SARIF file type
+      #   shell: bash
+      #   run: |
+      #     ls -la "${{ github.workspace }}"
+      #     file "${{ github.workspace }}/results.sarif"
+
+      # - name: "📋 Summarize and Print Checkov Scan Report with Snippets"
+      #   id: summarize-report
+      #   uses: subhamay-bhattacharyya-gha/checkov-report-action@main
+
+  build-lambda:
+    name: 🛠️ ⛔ Lambda Package
+    if: ${{ toJSON(needs.execution-path.outputs.execution-path).lambda == true }}
+    runs-on: ubuntu-latest
+    needs: [execution-path]
+    steps:
+      - name: Build and Upload Lambda Package
+        run: echo "Uploading Lambda package..."
+
+  build-lambda-layer:
+    name: 🛠️ ⛔ Lambda Layer
+    if: ${{ toJSON(needs.execution-path.outputs.execution-path)['lambda-layer'] == true }}
+    runs-on: ubuntu-latest
+    needs: [execution-path]
+    steps:
+    
+      - name: Build Lambda Layer Package
+        run: echo "No changes in Lambda layer package, skipping build..."
+
+      - name: Build and Upload Lambda Layer Package
+        run: echo "Build and Upload Lambda layer...."
+
+  build-glue:
+    name: 🛠️ ⛔ Glue Script
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).glue == true }}
+    runs-on: ubuntu-latest
+    needs: [execution-path]
+
+      - name: Package Glue Script
+        run: echo "No changes found in Glue script, skipping build..."
+
+      - name: Package and Upload Glue Script
+        run: echo "Uploading Glue script..."
+
+  build-state-machine:
+    name: 🛠️ ⛔ State Machine
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path)['state-machine'] == true }}
+    runs-on: ubuntu-latest
+    needs: [execution-path]
+    steps:
+
+      - name: Package State Machine
+        run: echo "No changes in State Machine, skipping build."
+
+      - name: Upload State Machine ASL
+        run: echo "Uploading State Machine ASL..."
+
+  yor-resource-tagging:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    name: 📋 Apply Git Metadata Tags using YOR
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [ terraform-lint, terraform-validate, checkov-scan ]
+    steps:
+      - name: Call Yor Reusable Action
+        run: echo "Applying Git metadata tags using YOR..."
+        # uses: subhamay-bhattacharyya-gha/tf-yor-action@main
+        # with:
+        #   terraform-dir: ${{ inputs.terraform-dir }}
+         
+  terraform-plan:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    name: 📋 Terraform Plan
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [ yor-resource-tagging ]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # - name: Terraform Plan
+      #   id: plan
+      #   uses: subhamay-bhattacharyya-gha/tf-plan-action@main
+      #   with:
+      #     terraform-dir: ${{ inputs.terraform-dir }} 
+      #     tf-vars-file: ${{ inputs.tf-vars-file }}
+      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+      #     s3-region: ${{ vars.AWS_REGION }}
+      #     ci-pipeline: ${{ inputs.ci-pipeline }}
+
+  infra-cost:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    name: 💰 Infra Cost
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [terraform-plan]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # - name: Infra Cost
+      #   id: infra-cost
+      #   uses: subhamay-bhattacharyya-gha/infracost-action@main
+      #   with:
+      #     terraform-dir: ${{ inputs.terraform-dir }} 
+      #     ci-pipeline: ${{ inputs.ci-pipeline }}
+      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+      #     s3-region: ${{ vars.AWS_REGION }}
+      #     infracost-api-key: ${{ secrets.infracost-api-key }}
+      #     gist-id: ${{ secrets.infracost-gist-id }}
+      #     environment: ${{ inputs.environment }}
+
+  terraform-apply:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    name: 🚧 Terraform Apply
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [infra-cost]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # - name: Terraform Apply
+      #   uses: subhamay-bhattacharyya-gha/tf-apply-action@main
+      #   id: apply
+      #   with:
+      #     terraform-dir: ${{ inputs.terraform-dir }}
+      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+      #     s3-region: ${{ vars.AWS_REGION }}
+      #     ci-pipeline: ${{ inputs.ci-pipeline }}
+
+  terraform-destroy:
+    if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
+    name: ✂️ Terraform Destroy
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    needs: [terraform-apply]
+    steps:
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # - name: Terraform Destroy
+      #   uses: subhamay-bhattacharyya-gha/tf-destroy-action@main
+      #   id: destroy
+      #   with:
+      #     terraform-dir: ${{ inputs.terraform-dir }}
+      #     s3-bucket: ${{ vars.TF_STATE_BUCKET_NAME }}
+      #     s3-region: ${{ vars.AWS_REGION }}
+      #     ci-pipeline: ${{ inputs.ci-pipeline }}
+
+  create-release:
+    name: 🚀 Create Release
+    runs-on: ubuntu-latest
+    if: |
+        (needs.build-lambda.result == 'success' ||
+          needs.build-lambda-layer.result == 'success' ||
+          needs.build-glue.result == 'success' ||
+          needs.build-state-machine.result == 'success' ||
+          needs.terraform-destroy.result == 'success')
+    needs: 
+    - build-lambda
+    - build-lambda-layer
+    - build-glue
+    - build-state-machine
+    - terraform-validate
+    - terraform-lint
+    - checkov-scan
+    - infra-cost
+    - terraform-plan
+    - terraform-apply
+    - terraform-destroy
+    steps:
+      - name: Create Release
+        run: echo "Creating release..."
+        # uses: subhamay-bhattacharyya-gha/create-release-action@main
+        # with:
+        #   github-token: ${{ secrets.GITHUB_TOKEN }}
+        #   tag-name: ${{ github.ref_name }}
+        #   release-name: Release ${{ github.ref_name }}
+        #   release-body: |
+        #     This is an automated release created by the CI pipeline.
+        #     It includes the latest changes from the main branch.
+        #   draft: false
+        #   prerelease: false

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -157,7 +157,8 @@ jobs:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).glue == true }}
     runs-on: ubuntu-latest
     needs: [execution-path]
-
+    
+    steps:
       - name: Package Glue Script
         run: echo "No changes found in Glue script, skipping build..."
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -183,7 +183,6 @@ jobs:
     needs: [ terraform-lint, terraform-validate, checkov-scan ]
     steps:
       - name: Call Yor Reusable Action
-        run: echo "Applying Git metadata tags using YOR..."
         uses: subhamay-bhattacharyya-gha/tf-yor-action@main
         with:
           terraform-dir: ${{ inputs.terraform-dir }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -40,6 +40,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  actions: read
 
 jobs:
 
@@ -49,10 +50,66 @@ jobs:
     outputs:
       execution-path: ${{ steps.set-path.outputs.execution-path }}
     steps:
-      - name: Set Execution Path
-        id: set-path
+      - name: Get Workflow Runs
+        id: get_runs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: context.payload.pull_request.head.ref,
+              event: "push"
+            });
+
+            const run = runs.data.workflow_runs.find(r => r.head_sha === context.payload.pull_request.head.sha);
+            if (!run) {
+              core.setFailed("No matching workflow run found for the feature branch.");
+              return;
+            }
+
+            core.setOutput("run_id", run.id);
+
+      - name: List Artifacts
+        id: list_artifacts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ steps.get_runs.outputs.run_id }},
+            });
+
+            const artifact = artifacts.data.artifacts.find(a => a.name === "execution-path-data");
+            if (!artifact) {
+              core.setFailed("Artifact 'execution-path-data' not found.");
+              return;
+            }
+
+            core.setOutput("artifact_id", artifact.id);
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          # You cannot directly download across runs. Use the REST API:
+          name: execution-path-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "execution-path={\"IaC\": true, \"lambda\": true, \"lambda-layer\": false, \"glue\": false, \"state-machine\": false}" >> $GITHUB_OUTPUT
+          curl -L \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ steps.list_artifacts.outputs.artifact_id }}/zip \
+            -o artifact.zip
+
+          unzip artifact.zip -d ./execution-path-data
+
+          echo "execution-path=`cat ./execution-path-data/execution-path.json`" >> $GITHUB_OUTPUT
+
+      # - name: Set Execution Path
+      #   id: set-path
+      #   run: |
+      #     echo "execution-path={\"IaC\": true, \"lambda\": true, \"lambda-layer\": false, \"glue\": false, \"state-machine\": false}" >> $GITHUB_OUTPUT
 
   terraform-validate:
     if: ${{ fromJSON(needs.execution-path.outputs.execution-path).IaC == true }}
@@ -274,19 +331,35 @@ jobs:
   create-release:
     name: 🚀 Create Release
     runs-on: ubuntu-latest
-    if: ${{ needs.build-lambda.result == 'success' || needs.build-lambda-layer.result == 'success' || needs.build-glue.result == 'success' || needs.build-state-machine.result == 'success' || needs.terraform-destroy.result == 'success' }}
     needs:
-      - build-lambda
-      - build-lambda-layer
-      - build-glue
-      - build-state-machine
-      - terraform-validate
-      - terraform-lint
-      - checkov-scan
-      - infra-cost
-      - terraform-plan
-      - terraform-apply
-      - terraform-destroy
+    - terraform-lint
+    - terraform-validate
+    - terraform-plan
+    - terraform-apply
+    - terraform-destroy
+    - infra-cost
+    - yor-resource-tagging
+    - checkov-scan
+    - build-lambda
+    - build-lambda-layer
+    - build-glue
+    - build-state-machine
+    if: >-
+      ${{
+        always() &&
+        needs.terraform-lint.result != 'failure' &&
+        needs.terraform-validate.result != 'failure' &&
+        needs.terraform-plan.result != 'failure' &&
+        needs.terraform-apply.result != 'failure' &&
+        needs.terraform-destroy.result != 'failure' &&
+        needs.infra-cost.result != 'failure' &&
+        needs.yor-resource-tagging.result != 'failure' &&
+        needs.checkov-scan.result != 'failure' &&
+        needs.build-lambda.result != 'failure' &&
+        needs.build-lambda-layer.result != 'failure' &&
+        needs.build-glue.result != 'failure' &&
+        needs.build-state-machine.result != 'failure'
+      }}
     steps:
       - name: Create Release
         uses: subhamay-bhattacharyya-gha/create-release-action@feature/GHA-0002-initial-release

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -88,11 +88,13 @@ jobs:
             }
 
             core.setOutput("artifact_id", artifact.id);
+
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:
-          # You cannot directly download across runs. Use the REST API:
           name: execution-path-data
+
+      - name: Unzip and Read Execution Path
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -105,6 +107,7 @@ jobs:
           unzip artifact.zip -d ./execution-path-data
 
           echo "execution-path=`cat ./execution-path-data/execution-path.json`" >> $GITHUB_OUTPUT
+
 
       # - name: Set Execution Path
       #   id: set-path


### PR DESCRIPTION
This pull request introduces a comprehensive, reusable GitHub Actions workflow for automating CI/CD processes with Terraform. The new workflow covers the entire infrastructure pipeline, including validation, linting, security scanning, build steps for AWS resources, cost estimation, and release creation. It is parameterized for different environments and designed to be triggered by other workflows or manually.

The most important changes are:

**Workflow Foundation and Inputs**
* Added a new reusable workflow file `.github/workflows/create-release.yaml` that defines a full CI/CD pipeline for Terraform-based infrastructure, including detailed input parameters and secret requirements for flexible and secure operation.

**Infrastructure as Code (IaC) Automation**
* Implemented jobs for Terraform validation, linting, security scanning (Checkov), resource tagging (YOR), planning, applying, destroying infrastructure, and cost estimation (Infracost), all orchestrated with conditional execution based on detected changes.

**AWS Resource Build Steps**
* Added build steps for AWS Lambda, Lambda Layers, Glue scripts, and State Machines, each triggered only if relevant changes are detected in the execution path artifact.

**Artifact and Execution Path Management**
* Introduced an initial job to retrieve and process an "execution path" artifact, which determines which downstream jobs (e.g., build, validate, scan) should run, optimizing the workflow for changed components only. (